### PR TITLE
Simplified API for parsing arbitrary _nt_ productions

### DIFF
--- a/lib/treetop/runtime/compiled_parser.rb
+++ b/lib/treetop/runtime/compiled_parser.rb
@@ -15,7 +15,7 @@ module Treetop
       def parse(input, options = {})
         prepare_to_parse(input)
         @index = options[:index] if options[:index]
-        result = send("_nt_#{root}")
+        result = send("_nt_#{options[:root] || root}")
         return nil if (consume_all_input? && index != input.size)
         return SyntaxNode.new(input, index...(index + 1)) if result == true
         return result


### PR DESCRIPTION
A simple modification in one line gives `parse` a `root` option.  With it one can simply type

<pre>
  def setup ; @parser = LambdaCalculus.new ; end
...
  result = @parser.parse text, root: :function
</pre>

instead of 

<pre>
...
  @parser.root = "function"
  result = @parser.parse text
  @parser.root = "program"
</pre>

The existing/old interface is unchanged, so no code breaks.
