### PR TITLE
small indent fix

### DIFF
--- a/lib/treetop/compiler/node_classes/grammar.rb
+++ b/lib/treetop/compiler/node_classes/grammar.rb
@@ -24,5 +24,5 @@ module Treetop
         grammar_name.text_value + 'Parser'
       end
     end
- end 
+  end 
 end

--- a/lib/treetop/compiler/node_classes/terminal.rb
+++ b/lib/treetop/compiler/node_classes/terminal.rb
@@ -16,5 +16,5 @@ module Treetop
         end
       end
     end
- end
+  end
 end


### PR DESCRIPTION
run with `ruby -w`

```
/usr/lib/ruby/gems/1.9.1/gems/treetop-1.4.9/lib/treetop/compiler/node_classes/grammar.rb:27: warning: mismatched indentations at 'end' with 'module' at 2
/usr/lib/ruby/gems/1.9.1/gems/treetop-1.4.9/lib/treetop/compiler/node_classes/terminal.rb:19: warning: mismatched indentations at 'end' with 'module' at 2
```
