### PR TITLE
Use a Regexp compatible with Ruby1.8.

### DIFF
--- a/spec/compiler/character_class_spec.rb
+++ b/spec/compiler/character_class_spec.rb
@@ -86,7 +86,7 @@ module CharacterClassSpec
   end
 
   describe "a character class with a negated POSIX bracket expression" do
-    testing_expression "[[:^space:]]"
+    testing_expression "[^[:space:]]"
     it "matches a character outside the negated class" do
       parse('a').should_not be_nil
     end


### PR DESCRIPTION
[[:^space:]] is not a valid Regexp character class for Ruby1.8. This patch changes it to the equivalent [^[:space:]].
This would solve https://github.com/nathansobo/treetop/issues/32 issue with specs.
